### PR TITLE
fix(readme): update stale proposal authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ assertion has occurred.
 
 This proposal has not yet been introduced to TC39.
 
-Authors:
+## Authors
 
-- [@DerekNonGeneric](https://github.com/DerekNonGeneric) (Derek Lewis, Indiana
-  University)
-- Champion: TBD
+- [@DerekNonGeneric](https://github.com/DerekNonGeneric) (Derek Lewis, AMPHTML / OpenINF)
+- Spec. Guest(s):
+  - [@boneskull](https://github.com/boneskull) (Chris Hiller, Mocha)
+    
+ ### Champion Group
+    
+  - Invited Expert(s):
+    - TBD
+  - Delegates(s):
+    - TBD
 
 ## Motivation
 


### PR DESCRIPTION
This will be both updating the original proposal author affiliation to be present-day accurate (AMPHTML / OpenINF) and welcoming @boneskull (AngularJS Edge / Mocha) as a special guest, which recognizes him acknowledging that his input into the proposal would be welcome and grants him maintainer access to the proposal repo allowing for any assistance he can provide with maintaining info currency and general upkeep.